### PR TITLE
add link in delete flash message in cart

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -31,7 +31,7 @@ class CartsController < ApplicationController
     @cart.delete_creature(creature.id)
     session[:cart] = @cart.contents
 
-    flash[:notice] = "You now have deleted #{creature.breed}."
+    flash[:notice] = "Successfully removed #{view_context.link_to(creature.breed, creature_path(creature))} from your cart."
 
     redirect_back(fallback_location: root_path)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
       <%= link_to "View Cart", carts_path %>
     </div> -->
     <% flash.each do |type, message| %>
-      <%= content_tag :div, message, class: type %>
+      <%= content_tag :div, message.html_safe, class: type %>
     <% end %>
     <%= yield %>
   </body>

--- a/spec/features/user_can_remove_item_from_cart_spec.rb
+++ b/spec/features/user_can_remove_item_from_cart_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "User is able to remove items from cart" do
       within "li#creature-#{creature2.id}" do
         click_on "Add to Cart"
       end
-      within "div.nav" do
+      within "div.nav-wrapper" do
         click_on "View Cart"
       end
 
@@ -24,6 +24,9 @@ RSpec.feature "User is able to remove items from cart" do
       end
 
       expect(current_path).to eq(carts_path)
+      expect(page).to have_content("Successfully removed #{creature1.breed} from your cart.")
+      expect(page).to have_link("#{creature1.breed}")
+      save_and_open_page
       expect(page).to_not have_content("Breed: #{creature1.breed}")
       expect(page).to have_content("Breed: #{creature2.breed}")
     end


### PR DESCRIPTION
this was a user story we initially overlooked

we added a link to the creature that was just removed, linking to the creature show page, in the event the user wants to visit the show page to re-add the creature.

closes issue #35 