### PR TITLE
Add create creature button on admin dashboard closes #96

### DIFF
--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -14,5 +14,7 @@
   <br>
   <%= link_to 'Orders', admin_orders_path, class: 'btn' %>
   <br>
+  <%= link_to 'Create Creature', new_admin_creature_path, class: 'btn' %>
+  <br>
   <%= link_to 'View All Creatures', admin_creatures_path, class: 'btn' %>
 </div>

--- a/spec/features/admin_can_create_an_item_spec.rb
+++ b/spec/features/admin_can_create_an_item_spec.rb
@@ -8,7 +8,9 @@ RSpec.feature 'Admin can create an item' do
     create :category, name: 'wtf'
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
-    visit new_admin_creature_path
+    visit admin_dashboard_path
+
+    click_on 'Create Creature'
   end
   context 'all input provided' do
     scenario 'admin creates an item' do


### PR DESCRIPTION
updated 'admin can create a creature' test to look for create creature button on the admin dashboard, got tests passing again.